### PR TITLE
Workaround for large object size

### DIFF
--- a/R/globals.R
+++ b/R/globals.R
@@ -357,7 +357,7 @@ getGlobalsAndPackages <- function(expr, envir = parent.frame(), tweak = tweakExp
       sizes <- lapply(globals, FUN = objectSize)
       sizes <- unlist(sizes, use.names = TRUE)
       total_size <- sum(sizes, na.rm = TRUE)
-      attr(globals, "total_size") <- total_size
+      attr(globals, "total_size") <- as.numeric(total_size)
       msg <- summarize_size_of_globals(globals, sizes = sizes,
                                        maxSize = maxSize, exprOrg = exprOrg,
                                        debug = debug)


### PR DESCRIPTION
This PR is to solve the problem when dealing with large object size, by casting `total_size` as a numeric object when it is stored as an attribute in `globals`.

When the integer class `total_size` exceed the `.Machine$integer.max` limit, users will receive the `integer overflow` warning message when `FutureGlobals` calculates `size` as I quoted below, and `size` will be `NA` as the result.

```
Warning message in size + sum(size_args, na.rm = FALSE):
“NAs produced by integer overflow”
```

https://github.com/futureverse/future/blob/568e39aa60cee581b1e79de6815916fd94c6ba53/R/FutureGlobals-class.R#L85-L102

This has been reported when using other R packages that use `future` for parallelisation, for example https://github.com/satijalab/seurat/issues/9316, https://github.com/satijalab/seurat/issues/9484, https://github.com/jinworks/CellChat/issues/250.
