### PR TITLE
update Japanese README on 2024-12-12

### DIFF
--- a/README_ja.md
+++ b/README_ja.md
@@ -1145,7 +1145,7 @@ install.packages("future")
 プレリリースバージョンは GitHub の `develop` ブランチにあり、インストールするには次のようにする。
 
 ``` r
-remotes::install_github("HenrikBengtsson/future", ref="develop")
+remotes::install_github("futureverse/future", ref="develop")
 ```
 
 これはソースからのインストールとなる。


### PR DESCRIPTION
I've updated the Japanese README.
I noticed that the repository name hadn't been changed to 'futureverse' in one place, so I corrected it.